### PR TITLE
Produce Windows arm64 builds.

### DIFF
--- a/electron/electron-builder.yml
+++ b/electron/electron-builder.yml
@@ -56,10 +56,12 @@ win:
           arch:
               - x64
               - ia32
+              - arm64
         - target: portable
           arch:
               - x64
               - ia32
+              - arm64
 
 nsis:
     artifactName: ${name}-${version}-setup-${os}-${arch}.${ext}


### PR DESCRIPTION
Electron already supports win/arm64. Add the flag to produce so.

Verified on an ARM64 device:

![image](https://user-images.githubusercontent.com/8717471/219030678-2c8490cd-f5da-44e2-bfbc-24b1e34df106.png)
